### PR TITLE
.hljsを無効化する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -63,6 +63,9 @@ textarea
 #preview
   padding: 1em
 
+.hljs
+  all: unset
+
 pre
   padding: 15px
   background-color: #282c34


### PR DESCRIPTION
# 目的
指定した`pre`のCSSを適用するため、.hljsのスタイルを無効化したい
# 実際に行ったこと
```sass
.hljs
  all: unset
```
を追記。
### 参考
- [all, initial, unsetでCSSのリセットと継承回避をする - fragmentary](https://myakura.hatenablog.com/entry/2013/12/11/183718)